### PR TITLE
manifest: Track hals msm8996 from LineageOS

### DIFF
--- a/snippets/crdroid.xml
+++ b/snippets/crdroid.xml
@@ -61,9 +61,9 @@
 
   <project path="hardware/interfaces" name="crdroidandroid/android_hardware_interfaces" remote="crdroid" />
   <project path="hardware/lineage/interfaces" name="crdroidandroid/android_hardware_lineage_interfaces" remote="crdroid" />
-  <project path="hardware/qcom-caf/msm8996/audio" name="crdroidandroid/android_hardware_qcom_audio" revision="11.0-caf-msm8996" />
-  <project path="hardware/qcom-caf/msm8996/display" name="crdroidandroid/android_hardware_qcom_display" revision="11.0-caf-msm8996" />
-  <project path="hardware/qcom-caf/msm8996/media" name="crdroidandroid/android_hardware_qcom_media" revision="11.0-caf-msm8996" />
+  <!--<project path="hardware/qcom-caf/msm8996/audio" name="crdroidandroid/android_hardware_qcom_audio" revision="11.0-caf-msm8996" />-->
+  <!--<project path="hardware/qcom-caf/msm8996/display" name="crdroidandroid/android_hardware_qcom_display" revision="11.0-caf-msm8996" />-->
+  <!--<project path="hardware/qcom-caf/msm8996/media" name="crdroidandroid/android_hardware_qcom_media" revision="11.0-caf-msm8996" />-->
   <project path="hardware/qcom-caf/msm8998/audio" name="crdroidandroid/android_hardware_qcom_audio" revision="11.0-caf-msm8998" />
   <project path="hardware/qcom-caf/msm8998/display" name="crdroidandroid/android_hardware_qcom_display" revision="11.0-caf-msm8998" />
   <project path="hardware/qcom-caf/msm8998/media" name="crdroidandroid/android_hardware_qcom_media" revision="11.0-caf-msm8998" />

--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -122,9 +122,9 @@
   <project path="hardware/qcom-caf/msm8994/audio" name="LineageOS/android_hardware_qcom_audio" groups="qcom,qcom_audio,pdk-qcom" revision="lineage-18.1-caf-msm8994" />
   <project path="hardware/qcom-caf/msm8994/display" name="LineageOS/android_hardware_qcom_display" groups="pdk-qcom,qcom,qcom_display" revision="lineage-18.1-caf-msm8994" />
   <project path="hardware/qcom-caf/msm8994/media" name="LineageOS/android_hardware_qcom_media" groups="qcom,pdk-qcom" revision="lineage-18.1-caf-msm8994" />
-  <!--<project path="hardware/qcom-caf/msm8996/audio" name="LineageOS/android_hardware_qcom_audio" groups="qcom,qcom_audio,pdk-qcom" revision="lineage-18.1-caf-msm8996" />-->
-  <!--<project path="hardware/qcom-caf/msm8996/display" name="LineageOS/android_hardware_qcom_display" groups="pdk-qcom,qcom,qcom_display" revision="lineage-18.1-caf-msm8996" />-->
-  <!--<project path="hardware/qcom-caf/msm8996/media" name="LineageOS/android_hardware_qcom_media" groups="qcom,pdk-qcom" revision="lineage-18.1-caf-msm8996" />-->
+  <project path="hardware/qcom-caf/msm8996/audio" name="LineageOS/android_hardware_qcom_audio" groups="qcom,qcom_audio,pdk-qcom" revision="lineage-18.1-caf-msm8996" />
+  <project path="hardware/qcom-caf/msm8996/display" name="LineageOS/android_hardware_qcom_display" groups="pdk-qcom,qcom,qcom_display" revision="lineage-18.1-caf-msm8996" />
+  <project path="hardware/qcom-caf/msm8996/media" name="LineageOS/android_hardware_qcom_media" groups="qcom,pdk-qcom" revision="lineage-18.1-caf-msm8996" />
   <!--<project path="hardware/qcom-caf/msm8998/audio" name="LineageOS/android_hardware_qcom_audio" groups="qcom,qcom_audio,pdk-qcom" revision="lineage-18.1-caf-msm8998" />-->
   <!--<project path="hardware/qcom-caf/msm8998/display" name="LineageOS/android_hardware_qcom_display" groups="pdk-qcom,qcom,qcom_display" revision="lineage-18.1-caf-msm8998" />-->
   <!--<project path="hardware/qcom-caf/msm8998/media" name="LineageOS/android_hardware_qcom_media" groups="qcom,pdk-qcom" revision="lineage-18.1-caf-msm8998" />-->


### PR DESCRIPTION
* platforms that use these hals like msm8937, msm8953 and sdm632, there is an incompatibility with the blobs of these platforms, which results in bootloop, so let's go back to the lineage hals.

Change-Id: I4fb9daef54acbb226d494ee771214db74dbeecb1